### PR TITLE
Automatic overlength option

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -316,6 +316,11 @@ set nocompatible
                     echo 'OverLength highlighting turned off'
                 endif
             endfunction
+            
+        """ Highlight automatically, no toggle, uncomment to enable {{{
+            " autocmd BufEnter * highlight OverLength ctermbg=DarkRed ctermfg=white guibg=#cf0000
+            " autocmd BufEnter * match OverLength /\%79v.*/
+        """ }}}
 
             nnoremap <leader>h :call ToggleOverLengthHighlight()<CR>
         """ }}}


### PR DESCRIPTION
Not entirely sure if you might think it's needed/wanted, but consider an automatic version of the overlength highlighting, as the toggling function doesn't seem to work (for me at least). Not entirely sure why.

It might prove useful to some people.
