### PR TITLE
Allow for more 256 colour terms

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -125,7 +125,7 @@ set nocompatible
             augroup END
         """ }}}
         """ 256 colors for maximum jellybeans bling. See commit log for info {{{
-            if (&term =~ "xterm") || (&term =~ "screen")
+            if (&term =~ "xterm") || (&term =~ "screen") || (&term =~ "256")
                 set t_Co=256
             endif
         """ }}}


### PR DESCRIPTION
Some terminals support 256 colours but don't have xterm or screen in their name string. rxvt-unicode-256color is a great example of this.
This patch enables jellybeans 256 colours for those terminals.
